### PR TITLE
Add InfluxDB prober node tag for multi-node support

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -12,6 +12,7 @@ host = "http://localhost:8086"
 org = "example-org"
 token = "REPLACE_WITH_TOKEN"
 bucket = "example-bucket"
+node_name = "region-xyz-node-a"
 
 [web]
 host = "127.0.0.1"

--- a/src/config.rs
+++ b/src/config.rs
@@ -18,6 +18,8 @@ pub struct InfluxDbConfig {
     pub org: String,
     pub token: String,
     pub bucket: String,
+    #[serde(default = "default_node_name")]
+    pub node_name: String,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -181,6 +183,7 @@ impl Default for InfluxDbConfig {
             org: "example-org".into(),
             token: "REPLACE_WITH_TOKEN".into(),
             bucket: "example-bucket".into(),
+            node_name: default_node_name(),
         }
     }
 }
@@ -211,4 +214,8 @@ impl Default for Config {
             teloxide: TeloxideConfig::default(),
         }
     }
+}
+
+fn default_node_name() -> String {
+    "default".to_string()
 }

--- a/src/influxdb.rs
+++ b/src/influxdb.rs
@@ -12,6 +12,7 @@ use async_trait::async_trait;
 pub struct InfluxUploader {
     client: Client,
     bucket: String,
+    node_name: String,
 }
 
 impl InfluxUploader {
@@ -25,6 +26,7 @@ impl InfluxUploader {
         Self {
             client,
             bucket: config.influxdb.bucket.clone(),
+            node_name: config.influxdb.node_name.clone(),
         }
     }
 
@@ -41,6 +43,7 @@ impl InfluxUploader {
                 DataPoint::builder("probe")
                     .tag("name", &result.name)
                     .tag("protocol", &result.protocol)
+                    .tag("node", &self.node_name)
                     .field("alive", true)
                     .field("delay_ms", result.delay_ms.unwrap() as i64)
                     .timestamp(timestamp)
@@ -49,6 +52,7 @@ impl InfluxUploader {
                 DataPoint::builder("probe")
                     .tag("name", &result.name)
                     .tag("protocol", &result.protocol)
+                    .tag("node", &self.node_name)
                     .field("alive", false)
                     .field("delay_ms", 99999)
                     .timestamp(timestamp)


### PR DESCRIPTION
This PR adds multi-node probing support in InfluxDB mode.

Changes:
- Config: introduce node_name under [influxdb] with serde default to preserve backward compatibility.
- Influx writer: tag every point with node=<node_name> so dashboards can aggregate across regions/nodes.
- Docs: update config.toml.example with a sample node_name.

Why: enables storing and differentiating results from multiple probing nodes (e.g., different regions) in the same bucket, powering multi-region dashboards.

No behavioral changes for users who do not use InfluxDB or omit node_name (defaults to "default").
