### PR TITLE
Add multi-node probing support for InfluxDB

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -18,6 +18,7 @@ pub struct InfluxDbConfig {
     pub org: String,
     pub token: String,
     pub bucket: String,
+    pub node_name: String,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -181,6 +182,7 @@ impl Default for InfluxDbConfig {
             org: "example-org".into(),
             token: "REPLACE_WITH_TOKEN".into(),
             bucket: "example-bucket".into(),
+            node_name: "node-1".into(),
         }
     }
 }

--- a/src/influxdb.rs
+++ b/src/influxdb.rs
@@ -12,6 +12,7 @@ use async_trait::async_trait;
 pub struct InfluxUploader {
     client: Client,
     bucket: String,
+    node_name: String,
 }
 
 impl InfluxUploader {
@@ -25,6 +26,7 @@ impl InfluxUploader {
         Self {
             client,
             bucket: config.influxdb.bucket.clone(),
+            node_name: config.influxdb.node_name.clone(),
         }
     }
 
@@ -41,6 +43,7 @@ impl InfluxUploader {
                 DataPoint::builder("probe")
                     .tag("name", &result.name)
                     .tag("protocol", &result.protocol)
+                    .tag("node", &self.node_name)
                     .field("alive", true)
                     .field("delay_ms", result.delay_ms.unwrap() as i64)
                     .timestamp(timestamp)
@@ -49,6 +52,7 @@ impl InfluxUploader {
                 DataPoint::builder("probe")
                     .tag("name", &result.name)
                     .tag("protocol", &result.protocol)
+                    .tag("node", &self.node_name)
                     .field("alive", false)
                     .field("delay_ms", 99999)
                     .timestamp(timestamp)

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,6 +36,10 @@ struct Args {
     /// Generate config
     #[arg(long, default_value = "false")]
     generate_config: bool,
+
+    /// Node name override (overrides config file setting)
+    #[arg(long)]
+    node_name: Option<String>,
 }
 
 #[tokio::main]
@@ -49,7 +53,12 @@ async fn main() -> Result<()> {
         return Ok(());
     }
 
-    let config = crate::config::Config::load_from_file(args.config.as_str()).unwrap();
+    let mut config = crate::config::Config::load_from_file(args.config.as_str()).unwrap();
+
+    // Override node name from CLI if provided
+    if let Some(node_name) = args.node_name {
+        config.influxdb.node_name = node_name;
+    }
 
     // Initialize logging
     let level = if config.main.verbose {


### PR DESCRIPTION
## Summary
- Add `node_name` configuration field to InfluxDbConfig with default value "node-1"
- Include `node` tag in all InfluxDB data points for regional identification
- Add `--node-name` CLI argument to override config file setting
- Enables multiple probing nodes in different regions to write to the same InfluxDB instance

## Changes Made
- **src/config.rs**: Added `node_name` field to `InfluxDbConfig` struct and default implementation
- **src/influxdb.rs**: Modified `InfluxUploader` to include node name as tag in data points
- **src/main.rs**: Added CLI argument `--node-name` with config override logic

## Use Case
This allows running ClashProbe from multiple geographic locations (e.g., US-East, EU-West, Asia-Pacific) and having all results stored in the same InfluxDB database with proper node tagging for regional analysis.

## Test Plan
- [x] Code compiles successfully with `cargo check`
- [x] Configuration parsing works with new field
- [x] CLI argument override functionality implemented
- [ ] Manual testing with actual InfluxDB instance (requires setup)
- [ ] Verify data points include correct node tags

🤖 Generated with [Claude Code](https://claude.ai/code)